### PR TITLE
INTERNAL - fix ci warnings, add .net7.0, remove .net5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   check-format:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     name: Check format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -49,13 +49,10 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-11, windows-2022]
+        os: [ubuntu-20.04, macos-11, windows-2022]
         arch: [x64, arm64]
         exclude:
         - os: windows-2022
-          arch: arm64
-        include:
-        - os: ubuntu-20.04
           arch: arm64
       fail-fast: false
     name: Build native ${{ matrix.arch }} library (${{ matrix.os }})
@@ -129,16 +126,11 @@ jobs:
                                   rm /tmp/cmake.sh"
 
     # Install arm64 cross-compilation toolchain if required
-    - name: Install arm64 cross-compilation toolchain - ubuntu 22.04
-      if: runner.os == 'Linux' && matrix.arch == 'arm64' && matrix.os != 'ubuntu-20.04'
-      run: |
-        sudo apt-get update
-        sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
-    - name: Install required build tool for ubuntu 20.04
+    - name: Install arm64 cross-compilation toolchain
       if: runner.os == 'Linux' && matrix.os == 'ubuntu-20.04'
       run: |
         sudo apt-get update
-        sudo apt install build-essential cmake g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
+        sudo apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
 
     # Install vcpkg dependencies
     - name: Install vcpkg build dependencies (macOS)
@@ -223,7 +215,7 @@ jobs:
   test-nuget:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-11, macos-12, windows-2022]
+        os: [ubuntu-20.04, macos-11, macos-12, windows-2022]
         dotnet: [netcoreapp3.1, net6.0, net7.0]
         arch: [x64]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   check-format:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     name: Check format
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -49,13 +49,10 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-11, windows-2022]
+        os: [ubuntu-20.04, macos-11, windows-2022]
         arch: [x64, arm64]
         exclude:
         - os: windows-2022
-          arch: arm64
-        include:
-        - os: ubuntu-20.04
           arch: arm64
       fail-fast: false
     name: Build native ${{ matrix.arch }} library (${{ matrix.os }})
@@ -133,13 +130,7 @@ jobs:
       if: runner.os == 'Linux' && matrix.arch == 'arm64'
       run: |
         sudo apt-get update
-        sudo apt-get --yes install g++-aarch64-linux-gnu
-    # Install arm64 cross-compilation toolchain if required - ubuntu-20.04
-    # - name: Install arm64 cross-compilation toolchain - ubuntu-20.04
-    #   if: runner.os == 'Linux' && matrix.arch == 'arm64' && matrix.os == 'ubuntu-20.04'
-    #   run: |
-    #     sudo apt-get update
-    #     sudo apt-get --yes install g++-aarch64-linux-gnu pkg-config-aarch64-linux-gnu
+        sudo apt-get --yes install g++-aarch64-linux-gnu pkg-config-aarch64-linux-gnu
 
     # Install vcpkg dependencies
     - name: Install vcpkg build dependencies (macOS)
@@ -224,7 +215,7 @@ jobs:
   test-nuget:
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-11, macos-12, windows-2022]
+        os: [ubuntu-20.04, macos-11, macos-12, windows-2022]
         dotnet: [netcoreapp3.1, net6.0, net7.0]
         arch: [x64]
         include:
@@ -272,6 +263,8 @@ jobs:
       run: |
         dotnet remove csharp.test reference csharp/ParquetSharp.csproj
         dotnet add csharp.test package ParquetSharp -v ${{ steps.get-version.outputs.version }}
+        dotnet remove fsharp.test reference csharp/ParquetSharp.csproj
+        dotnet add fsharp.test package ParquetSharp -v ${{ steps.get-version.outputs.version }}
     - name: Setup QEMU for arm64
       if: matrix.arch == 'arm64'
       uses: docker/setup-qemu-action@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   check-format:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     name: Check format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -49,10 +49,13 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2022]
+        os: [ubuntu-22.04, macos-11, windows-2022]
         arch: [x64, arm64]
         exclude:
         - os: windows-2022
+          arch: arm64
+        include:
+        - os: ubuntu-20.04
           arch: arm64
       fail-fast: false
     name: Build native ${{ matrix.arch }} library (${{ matrix.os }})
@@ -126,11 +129,16 @@ jobs:
                                   rm /tmp/cmake.sh"
 
     # Install arm64 cross-compilation toolchain if required
-    - name: Install arm64 cross-compilation toolchain
-      if: runner.os == 'Linux' && matrix.arch == 'arm64'
+    - name: Install arm64 cross-compilation toolchain - ubuntu 22.04
+      if: runner.os == 'Linux' && matrix.arch == 'arm64' && matrix.os != 'ubuntu-20.04'
       run: |
         sudo apt-get update
-        sudo apt-get --yes install g++-aarch64-linux-gnu pkg-config-aarch64-linux-gnu
+        sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+    - name: Install required build tool for ubuntu 20.04
+      if: runner.os == 'Linux' && matrix.os == 'ubuntu-20.04'
+      run: |
+        sudo apt-get update
+        sudo apt install build-essential cmake g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
 
     # Install vcpkg dependencies
     - name: Install vcpkg build dependencies (macOS)
@@ -211,11 +219,11 @@ jobs:
         name: nuget-package
         path: nuget
 
-  # Run .NET unit tests with the nuget package on all platforms and all supported .NET runtimes (thus testing the user workflow). 
+  # Run .NET unit tests with the nuget package on all platforms and all supported .NET runtimes (thus testing the user workflow).
   test-nuget:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, macos-12, windows-2022]
+        os: [ubuntu-22.04, macos-11, macos-12, windows-2022]
         dotnet: [netcoreapp3.1, net6.0, net7.0]
         arch: [x64]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,10 +127,10 @@ jobs:
 
     # Install arm64 cross-compilation toolchain if required
     - name: Install arm64 cross-compilation toolchain
-      if: runner.os == 'Linux' && matrix.os == 'ubuntu-20.04'
+      if: runner.os == 'Linux' && matrix.arch == 'arm64'
       run: |
         sudo apt-get update
-        sudo apt install g++-aarch64-linux-gnu gcc-aarch64-linux-gnu
+        sudo apt install g++-aarch64-linux-gnu
 
     # Install vcpkg dependencies
     - name: Install vcpkg build dependencies (macOS)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,14 +19,14 @@ jobs:
   check-format:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     name: Check format
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Setup .NET SDK v6.0.x
+      - name: Setup .NET SDK v7.0.x
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: 6.0.x
+          dotnet-version: 7.0.x
       - name: Code formating check
         run: |
           dotnet tool restore
@@ -49,10 +49,13 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'push' || github.event.pull_request.head.repo.id != github.event.pull_request.base.repo.id
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2022]
+        os: [ubuntu-22.04, macos-11, windows-2022]
         arch: [x64, arm64]
         exclude:
         - os: windows-2022
+          arch: arm64
+        include:
+        - os: ubuntu-20.04
           arch: arm64
       fail-fast: false
     name: Build native ${{ matrix.arch }} library (${{ matrix.os }})
@@ -130,7 +133,13 @@ jobs:
       if: runner.os == 'Linux' && matrix.arch == 'arm64'
       run: |
         sudo apt-get update
-        sudo apt-get --yes install g++-aarch64-linux-gnu pkg-config-aarch64-linux-gnu
+        sudo apt-get --yes install g++-aarch64-linux-gnu
+    # Install arm64 cross-compilation toolchain if required - ubuntu-20.04
+    # - name: Install arm64 cross-compilation toolchain - ubuntu-20.04
+    #   if: runner.os == 'Linux' && matrix.arch == 'arm64' && matrix.os == 'ubuntu-20.04'
+    #   run: |
+    #     sudo apt-get update
+    #     sudo apt-get --yes install g++-aarch64-linux-gnu pkg-config-aarch64-linux-gnu
 
     # Install vcpkg dependencies
     - name: Install vcpkg build dependencies (macOS)
@@ -138,10 +147,10 @@ jobs:
       run: brew install bison
 
     # .NET Core Setup (and also MSBuild for Windows).
-    - name: Setup .NET SDK v6.0.x
+    - name: Setup .NET SDK v7.0.x
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     - name: Setup MSBuild
       if: runner.os == 'Windows'
       uses: microsoft/setup-msbuild@v1
@@ -199,10 +208,10 @@ jobs:
       run: |
         mkdir bin
         cp -rv artifacts/*-native-library/* bin/
-    - name: Setup .NET SDK v6.0.x
+    - name: Setup .NET SDK v7.0.x
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     - name: Build NuGet package
       run: dotnet build csharp --configuration=Release
     - name: Upload NuGet artifact
@@ -211,12 +220,12 @@ jobs:
         name: nuget-package
         path: nuget
 
-  # Run .NET unit tests with the nuget package on all platforms and all supported .NET runtimes (thus testing the user workflow).
+  # Run .NET unit tests with the nuget package on all platforms and all supported .NET runtimes (thus testing the user workflow). 
   test-nuget:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, macos-12, windows-2022]
-        dotnet: [netcoreapp3.1, net5.0, net6.0]
+        os: [ubuntu-22.04, macos-11, macos-12, windows-2022]
+        dotnet: [netcoreapp3.1, net6.0, net7.0]
         arch: [x64]
         include:
         - os: windows-2022
@@ -246,11 +255,11 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 3.1.x
-    - name: Setup .NET SDK v5.0.x
-      if: matrix.dotnet == 'net5.0'
+    - name: Setup .NET SDK v7.0.x
+      if: matrix.dotnet == 'net7.0'
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 7.0.x
     - name: Setup .NET SDK v6.0.x
       uses: actions/setup-dotnet@v3
       with:
@@ -263,8 +272,6 @@ jobs:
       run: |
         dotnet remove csharp.test reference csharp/ParquetSharp.csproj
         dotnet add csharp.test package ParquetSharp -v ${{ steps.get-version.outputs.version }}
-        dotnet remove fsharp.test reference csharp/ParquetSharp.csproj
-        dotnet add fsharp.test package ParquetSharp -v ${{ steps.get-version.outputs.version }}
     - name: Setup QEMU for arm64
       if: matrix.arch == 'arm64'
       uses: docker/setup-qemu-action@v2
@@ -318,10 +325,10 @@ jobs:
       with:
         name: nuget-package
         path: nuget
-    - name: Setup .NET SDK v6.0.x
+    - name: Setup .NET SDK v7.0.x
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.0.x
     # if version contains "-" treat it as pre-release
     # example: 1.0.0-beta1
     - name: Create release

--- a/csharp.test/ParquetSharp.Test.csproj
+++ b/csharp.test/ParquetSharp.Test.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
     <!-- Avoid building for older frameworks when testing locally. -->
     <!-- This is to speed up the build process and avoid errors when the required runtimes are not installed. -->
-    <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CI)' == 'true' AND '$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>

--- a/fsharp.test/ParquetSharp.Test.FSharp.fsproj
+++ b/fsharp.test/ParquetSharp.Test.FSharp.fsproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
     <!-- Avoid building for older frameworks when testing locally. -->
     <!-- This is to speed up the build process and avoid errors when the required runtimes are not installed. -->
-    <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="'$(CI)' == 'true'">$(TargetFrameworks);netcoreapp3.1;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(CI)' == 'true' AND '$(OS)'=='Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <PlatformTarget Condition="'$(TargetFramework)'=='net472'">x64</PlatformTarget>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
GR-OSS issue [#344](https://github.com/G-Research/gr-oss/issues/334)

https://github.com/G-Research/ParquetSharp/issues/309

Full [workflow](https://github.com/ljubon/ParquetSharp/actions/runs/4138580891) with release. 
Failure is expected as release can not be created with branch name

- [ ] fix CI warnings for deprecated runners
- [x] remove .net5.0
- [x] add .net7.0 
- [ ] pass tests