### PR TITLE
Lint: Update rules for formating code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup .NET SDK v7.0.x
         uses: actions/setup-dotnet@v3
         with:
@@ -34,7 +34,6 @@ jobs:
         run: |
           dotnet tool restore
           dotnet jb cleanupcode "csharp" "csharp.test" "csharp.benchmark" --profile="Built-in: Reformat Code" --settings="ParquetSharp.DotSettings" --verbosity=WARN
-
           files=($(git diff --name-only))
           if [ ${#files[@]} -gt 0 ]
           then

--- a/ParquetSharp.DotSettings
+++ b/ParquetSharp.DotSettings
@@ -4,4 +4,10 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSOR_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSORHOLDER_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ForceCamelCaseForLocalVariables/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ForceCamelCaseForParameters/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PrivateFieldsPrefix/@EntryValue">_</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/PrivateFieldsPrefixIsUnderscore/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MODIFIERS_ORDER/@EntryValue">public, private, protected, internal, static, new, virtual, abstract, override, readonly</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_USER_LINEBREAKS/@EntryValue">True</s:Boolean>
 </wpf:ResourceDictionary> 

--- a/ParquetSharp.DotSettings
+++ b/ParquetSharp.DotSettings
@@ -10,4 +10,5 @@
 	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/PrivateFieldsPrefixIsUnderscore/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MODIFIERS_ORDER/@EntryValue">public, private, protected, internal, static, new, virtual, abstract, override, readonly</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_USER_LINEBREAKS/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">True</s:Boolean>
 </wpf:ResourceDictionary> 


### PR DESCRIPTION
Based on existing rule sets in [ParquetSharp.DotSettings](https://github.com/ljubon/ParquetSharp/blob/oss-414-linting-lvl-4/ParquetSharp.DotSettings) and as part of [OSS-414](https://github.com/G-Research/oss-portfolio-maturity/issues/414) goal of this PR is to add new rules which are safe and not breaking current process, just enforcing existing syntax and style

_Optional_: I tried one more rule to add, but it's not part of this PR
Here are [changes ](https://github.com/ljubon/ParquetSharp/actions/runs/7506069064/job/20436665643#step:4:3173), total `67` file
Rule line is:
```xml
<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AFTER_TYPECAST_PARENTHESES/@EntryValue">False</s:Boolean>
```